### PR TITLE
map by default parameter types to string

### DIFF
--- a/argparse/argparse_cwl_translation.py
+++ b/argparse/argparse_cwl_translation.py
@@ -125,4 +125,4 @@ class ArgparseCWLTranslation:
         elif type(py_type).__name__ == 'builtin_function_or_method' or type(py_type).__name__ == 'FileType':
             return 'File'
         else:  # type given as a string: 'str', 'int' etc.
-            return PY_TO_CWL_TYPES[py_type]
+            return PY_TO_CWL_TYPES.get(py_type,None)


### PR DESCRIPTION
Some types cannot be inferred easily from the `type` parameter of `argparse.add_argument()`.
For instance, in a case of cnvkit, the value of type is a callable which makes a conversion of the data (see https://github.com/etal/cnvkit/blob/master/cnvlib/commands.py#L603). This is why I propose that in the case where a parameter type cannot be inferred, `get_cwl_type()` send back `None`, and the default type becomes string.
Previous to this modification, the call to argparse on cnvkit results in a KeyError:

```
Traceback (most recent call last):
  File "/home/hmenager/ap2tt/bin/cnvkit.py", line 12, in <module>
    args = commands.parse_args()
  File "/home/hmenager/ap2tt/local/lib/python2.7/site-packages/cnvlib/commands.py", line 2038, in parse_args
    return AP.parse_args(args=args)
  File "/home/hmenager/ap2tt/src/argparse2tool/argparse/__init__.py", line 81, in parse_args
    self.parse_args_cwl(*args, **kwargs)
  File "/home/hmenager/ap2tt/src/argparse2tool/argparse/__init__.py", line 111, in parse_args_cwl
    cwlt_parameter = methodToCall(result)
  File "/home/hmenager/ap2tt/src/argparse2tool/argparse/argparse_cwl_translation.py", line 83, in _StoreAction
    cwlparam = self.__cwl_param_from_type(param)
  File "/home/hmenager/ap2tt/src/argparse2tool/argparse/argparse_cwl_translation.py", line 57, in __cwl_param_from_type
    'type': self.get_cwl_type(param.type) or 'string'}
  File "/home/hmenager/ap2tt/src/argparse2tool/argparse/argparse_cwl_translation.py", line 129, in get_cwl_type
    return PY_TO_CWL_TYPES[py_type]
KeyError: <function csvstring at 0x7fd580e2f140>
```