### PR TITLE
handle if ArgumentParser.print_version() absent

### DIFF
--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -132,10 +132,14 @@ class ArgumentParser(ap.ArgumentParser):
         sys.exit(0)
 
     def parse_args_galaxy(self, *args, **kwargs):
+        try:
+            version = self.print_version() or '1.0'
+        except AttributeError: #handle the potential absence of print_version
+            version = '1.0'
         self.tool = gxt.Tool(
                 self.prog,
                 self.prog,
-                self.print_version() or '1.0',
+                version,
                 self.description,
                 self.prog,
                 interpreter='python',

--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -134,7 +134,7 @@ class ArgumentParser(ap.ArgumentParser):
     def parse_args_galaxy(self, *args, **kwargs):
         try:
             version = self.print_version() or '1.0'
-        except AttributeError: #handle the potential absence of print_version
+        except AttributeError:  # handle the potential absence of print_version
             version = '1.0'
         self.tool = gxt.Tool(
                 self.prog,


### PR DESCRIPTION
`ArgumentParser.print_version()` from `argparse` method is deprecated in python 2.7, but absent in 3.5 (maybe even earlier). This modification just handles the absence of the method by using the default '1.0' version, making it usablet in python 3.5.