### PR TITLE
correct foo parameter type

### DIFF
--- a/examples/example.cwl
+++ b/examples/example.cwl
@@ -32,7 +32,7 @@ inputs:
       position: 2
 
   foo:
-    type: ["null", str]
+    type: ["null", string]
     doc: foo help
     inputBinding:
       prefix: --foo 


### PR DESCRIPTION
strings are `string` in CWL, not `str`. I think this is what was causing the build to fail in #41