### PR TITLE
Revert "cwlVersion: v1.0 is good enough"

### DIFF
--- a/argparse2tool/cmdline2cwl/templates/cwltool.j2
+++ b/argparse2tool/cmdline2cwl/templates/cwltool.j2
@@ -3,7 +3,7 @@
 # To generate again: $ {{ formcommand }} --generate_cwl_tool
 # Help: $ {{ stripped_options_command }} --help_arg2cwl
 
-cwlVersion: v1.0
+cwlVersion: "cwl:v1.0"
 
 class: CommandLineTool
 baseCommand: {{ basecommand }}


### PR DESCRIPTION
Reverts erasche/argparse2tool#43 until the tests are fixed