### PR TITLE
modify cwl templates to output an empty array when no tool inputs

### DIFF
--- a/argparse2tool/cmdline2cwl/templates/cwltool_inputs.j2
+++ b/argparse2tool/cmdline2cwl/templates/cwltool_inputs.j2
@@ -1,3 +1,6 @@
+{% if not('python' in basecommand[0]) and not(tool.inputs) %}
+[]
+{% endif %}
 {% if 'python' in basecommand[0] %}
 {{ tool.name }}:
     type: File


### PR DESCRIPTION
otherwise the generated cwl is not syntactically valid