### PR TITLE
some improvements

### DIFF
--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -155,11 +155,11 @@ class ArgumentParser(ap.ArgumentParser):
             version = '1.0'
         tool = gxt.Tool(
                 argp.prog,
-                argp.prog,
+                argp.prog.replace(" ", "_"),
                 version,
                 argp.description,
-                argp.prog,
-                interpreter='python',
+                "python "+argp.prog,
+                interpreter=None,
                 version_command='python %s --version' % sys.argv[0])
 
         inputs = gxtp.Inputs()

--- a/argparse/__init__.py
+++ b/argparse/__init__.py
@@ -160,7 +160,7 @@ class ArgumentParser(ap.ArgumentParser):
                 argp.description,
                 "python "+argp.prog,
                 interpreter=None,
-                version_command='python %s --version' % sys.argv[0])
+                version_command='python %s --version' % argp.prog)
 
         inputs = gxtp.Inputs()
         outputs = gxtp.Outputs()

--- a/argparse/argparse_galaxy_translation.py
+++ b/argparse/argparse_galaxy_translation.py
@@ -11,11 +11,16 @@ class ArgparseGalaxyTranslation(object):
         if default is None and (param.type in (int, float)):
             default = 0
 
-        if param.choices is not None:
+        if param.type == int:
+            mn = None
+            mx = None
+            if param.choices is not None:
+                mn = min(param.choices)
+                mx = max(param.choices)
+            gxparam = gxtp.IntegerParam(flag, default, label=label, min=mn, max=mx, num_dashes=num_dashes, **gxparam_extra_kwargs)
+        elif param.choices is not None:
             choices = {k: k for k in param.choices}
             gxparam = gxtp.SelectParam(flag, default=default, label=label, num_dashes=num_dashes, options=choices, **gxparam_extra_kwargs)
-        elif param.type == int:
-            gxparam = gxtp.IntegerParam(flag, default, label=label, num_dashes=num_dashes, **gxparam_extra_kwargs)
         elif param.type == float:
             gxparam = gxtp.FloatParam(flag, default, label=label, num_dashes=num_dashes, **gxparam_extra_kwargs)
         elif param.type is None or param.type == str:
@@ -164,7 +169,7 @@ class ArgparseGalaxyTranslation(object):
 
         # Moved because needed in developing repeat CLI
         if positional:
-            flag_wo_dashes = '%s_%s\n' %(param.dest, self.positional_count)
+            flag_wo_dashes = '%s_%s' %(param.dest, self.positional_count)
             # SO unclean
             gxparam_extra_kwargs['positional'] = True
 

--- a/argparse/argparse_galaxy_translation.py
+++ b/argparse/argparse_galaxy_translation.py
@@ -164,7 +164,7 @@ class ArgparseGalaxyTranslation(object):
 
         # Moved because needed in developing repeat CLI
         if positional:
-            flag_wo_dashes = 'positional_%s' % self.positional_count
+            flag_wo_dashes = '%s_%s\n' %(param.dest, self.positional_count)
             # SO unclean
             gxparam_extra_kwargs['positional'] = True
 

--- a/argparse/argparse_galaxy_translation.py
+++ b/argparse/argparse_galaxy_translation.py
@@ -1,6 +1,6 @@
 import galaxyxml.tool.parameters as gxtp
+from collections import Counter
 from pydoc import locate
-
 
 class ArgparseGalaxyTranslation(object):
 
@@ -125,7 +125,7 @@ class ArgparseGalaxyTranslation(object):
 
     def __init__(self):
         self.repeat_count = 0
-        self.positional_count = 0
+        self.positional_count = Counter()
 
     def _VersionAction(self, param, tool=None):
         # passing tool is TERRIBLE, I know.
@@ -158,7 +158,7 @@ class ArgparseGalaxyTranslation(object):
             flag = max(param.option_strings, key=len)  # Pick the longest of the options strings
         else:
             flag = ''
-            self.positional_count += 1
+            self.positional_count['param.dest'] += 1
 
         repeat_name = 'repeat_%s' % self.repeat_count
         repeat_var_name = 'repeat_var_%s' % self.repeat_count
@@ -169,7 +169,8 @@ class ArgparseGalaxyTranslation(object):
 
         # Moved because needed in developing repeat CLI
         if positional:
-            flag_wo_dashes = '%s_%s' %(param.dest, self.positional_count)
+            v = self.positional_count[param.dest]
+            flag_wo_dashes = '%s%s' % (param.dest, '_' + str(v) if v > 1 else '')
             # SO unclean
             gxparam_extra_kwargs['positional'] = True
 

--- a/argparse/argparse_galaxy_translation.py
+++ b/argparse/argparse_galaxy_translation.py
@@ -2,6 +2,7 @@ import galaxyxml.tool.parameters as gxtp
 from collections import Counter
 from pydoc import locate
 
+
 class ArgparseGalaxyTranslation(object):
 
     def __gxtp_param_from_type(self, param, flag, label, num_dashes, gxparam_extra_kwargs, default=None):

--- a/examples/example-sub.xml
+++ b/examples/example-sub.xml
@@ -3,7 +3,7 @@
   <stdio>
     <exit_code level="fatal" range="1:"/>
   </stdio>
-  <version_command>python example-sub.py --version</version_command>
+  <version_command>python example-sub.py foo --version</version_command>
   <command><![CDATA[python example-sub.py foo $keyword
 
 #set repeat_var_2 = '" "'.join([ str($var.integers) for $var in $repeat_2 ])
@@ -43,7 +43,7 @@ $true
   <stdio>
     <exit_code level="fatal" range="1:"/>
   </stdio>
-  <version_command>python example-sub.py --version</version_command>
+  <version_command>python example-sub.py bar --version</version_command>
   <command><![CDATA[python example-sub.py bar $false
 #for $i in $repeat_1:
 --append $i.append

--- a/examples/example-sub.xml
+++ b/examples/example-sub.xml
@@ -3,8 +3,8 @@
   <stdio>
     <exit_code level="fatal" range="1:"/>
   </stdio>
-  <version_command>python examples/example-sub.py --version</version_command>
-  <command><![CDATA[python examples/example-sub.py foo $keyword
+  <version_command>python example-sub.py --version</version_command>
+  <command><![CDATA[python example-sub.py foo $keyword
 
 #set repeat_var_2 = '" "'.join([ str($var.integers) for $var in $repeat_2 ])
 "$repeat_var_2"
@@ -43,8 +43,8 @@ $true
   <stdio>
     <exit_code level="fatal" range="1:"/>
   </stdio>
-  <version_command>python examples/example-sub.py --version</version_command>
-  <command><![CDATA[python examples/example-sub.py bar $false
+  <version_command>python example-sub.py --version</version_command>
+  <command><![CDATA[python example-sub.py bar $false
 #for $i in $repeat_1:
 --append $i.append
 #end for

--- a/examples/example-sub.xml
+++ b/examples/example-sub.xml
@@ -1,12 +1,12 @@
-<tool id="example-sub.py foo" name="example-sub.py foo" version="1.0">
+<tool id="example-sub.py_foo" name="example-sub.py foo" version="1.0">
   <description/>
   <stdio>
     <exit_code level="fatal" range="1:"/>
   </stdio>
-  <version_command>python examples/example-sub.py --version</version_command>
-  <command interpreter="python"><![CDATA[example-sub.py foo $positional_1
+  <version_command>python example-sub.py --version</version_command>
+  <command><![CDATA[python example-sub.py foo $keyword
 
-#set repeat_var_2 = '" "'.join([ str($var.positional_2) for $var in $repeat_2 ])
+#set repeat_var_2 = '" "'.join([ str($var.integers) for $var in $repeat_2 ])
 "$repeat_var_2"
 
 $sum
@@ -21,9 +21,9 @@ $sum
 $true
 > $default]]></command>
   <inputs>
-    <param area="false" label="action keyword" name="positional_1" type="text"/>
+    <param area="false" label="action keyword" name="keyword" type="text"/>
     <repeat min="1" name="repeat_2" title="repeat_title">
-      <param label="an integer for the accumulator" name="positional_2" type="integer" value="0"/>
+      <param label="an integer for the accumulator" name="integers" type="integer" value="0"/>
     </repeat>
     <param argument="--sum" checked="false" label="sum the integers (default: find the max)" name="sum" type="boolean" truevalue="--sum" falsevalue=""/>
     <param area="false" argument="--foo" label="foo help" name="foo" optional="true" type="text"/>
@@ -38,13 +38,13 @@ $true
   <help><![CDATA[TODO: Write help]]></help>
 </tool>
 
-<tool id="example-sub.py bar" name="example-sub.py bar" version="2.0">
+<tool id="example-sub.py_bar" name="example-sub.py bar" version="2.0">
   <description/>
   <stdio>
     <exit_code level="fatal" range="1:"/>
   </stdio>
-  <version_command>python examples/example-sub.py --version</version_command>
-  <command interpreter="python"><![CDATA[example-sub.py bar $false
+  <version_command>python example-sub.py --version</version_command>
+  <command><![CDATA[python example-sub.py bar $false
 #for $i in $repeat_1:
 --append $i.append
 #end for

--- a/examples/example-sub.xml
+++ b/examples/example-sub.xml
@@ -3,8 +3,8 @@
   <stdio>
     <exit_code level="fatal" range="1:"/>
   </stdio>
-  <version_command>python example-sub.py --version</version_command>
-  <command><![CDATA[python example-sub.py foo $keyword
+  <version_command>python examples/example-sub.py --version</version_command>
+  <command><![CDATA[python examples/example-sub.py foo $keyword
 
 #set repeat_var_2 = '" "'.join([ str($var.integers) for $var in $repeat_2 ])
 "$repeat_var_2"
@@ -43,8 +43,8 @@ $true
   <stdio>
     <exit_code level="fatal" range="1:"/>
   </stdio>
-  <version_command>python example-sub.py --version</version_command>
-  <command><![CDATA[python example-sub.py bar $false
+  <version_command>python examples/example-sub.py --version</version_command>
+  <command><![CDATA[python examples/example-sub.py bar $false
 #for $i in $repeat_1:
 --append $i.append
 #end for

--- a/examples/example.xml
+++ b/examples/example.xml
@@ -3,10 +3,10 @@
   <stdio>
     <exit_code level="fatal" range="1:"/>
   </stdio>
-  <version_command>python examples/example.py --version</version_command>
-  <command interpreter="python"><![CDATA[example.py $positional_1
+  <version_command>python example.py --version</version_command>
+  <command><![CDATA[python example.py $keyword
 
-#set repeat_var_2 = '" "'.join([ str($var.positional_2) for $var in $repeat_2 ])
+#set repeat_var_2 = '" "'.join([ str($var.integers) for $var in $repeat_2 ])
 "$repeat_var_2"
 
 $sum
@@ -32,9 +32,9 @@ $false
 #end if
 > $default]]></command>
   <inputs>
-    <param area="false" label="action keyword" name="positional_1" type="text"/>
+    <param area="false" label="action keyword" name="keyword" type="text"/>
     <repeat min="1" name="repeat_2" title="repeat_title">
-      <param label="an integer for the accumulator" name="positional_2" type="integer" value="0"/>
+      <param label="an integer for the accumulator" name="integers" type="integer" value="0"/>
     </repeat>
     <param argument="--sum" checked="false" label="sum the integers (default: find the max)" name="sum" type="boolean" truevalue="--sum" falsevalue=""/>
     <param area="false" argument="--foo" label="foo help" name="foo" optional="true" type="text"/>


### PR DESCRIPTION
https://github.com/erasche/argparse2tool/issues/62

- [x] remove spaces in tool name (problem comes for subcommands)
- [x] `<command interpreter="python"><!\[CDATA\[` -> `<command><!\[CDATA\[python`
- [ ] non optional positional arguments are currently treated as optional in the galaxy xml file
- [x] use the NAME_NUMBER of positional arguments instead of positional_NUMBER? 

For the 3rd one I do not know where to start...

For the last one I do not know if I can savely remove the NUMBER.

- [x] correct processing of integer arguments (were rendered as select). now they have min and max

While working on checkm I might stumble over other improvements an add them here.